### PR TITLE
Fix for Issue 5: MemberAPI should export default new MemberAPI

### DIFF
--- a/04 DisplayData/src/api/memberAPI.ts
+++ b/04 DisplayData/src/api/memberAPI.ts
@@ -3,14 +3,16 @@ import MembersMockData from './memberMockData'
 import * as _ from 'lodash'
 // Sync mock data API, inspired from:
 // https://gist.github.com/coryhouse/fd6232f95f9d601158e4
-export default class MemberAPI {
+class MemberAPI {
   //This would be performed on the server in a real app. Just stubbing in.
-  private static _clone (item) {
+  private _clone (item) {
   	return JSON.parse(JSON.stringify(item)); //return cloned copy so that the item is passed by value instead of by reference
   };
 
   // Just return a copy of the mock data
-  static getAllMembers() : Array<MemberEntity> {
+  getAllMembers() : Array<MemberEntity> {
 		return this._clone(MembersMockData);
 	}
 }
+
+export default new MemberAPI();

--- a/04 DisplayData/src/api/memberAPI.ts
+++ b/04 DisplayData/src/api/memberAPI.ts
@@ -5,12 +5,12 @@ import * as _ from 'lodash'
 // https://gist.github.com/coryhouse/fd6232f95f9d601158e4
 export default class MemberAPI {
   //This would be performed on the server in a real app. Just stubbing in.
-  private _clone (item) {
+  private static _clone (item) {
   	return JSON.parse(JSON.stringify(item)); //return cloned copy so that the item is passed by value instead of by reference
   };
 
   // Just return a copy of the mock data
-  getAllMembers() : Array<MemberEntity> {
+  static getAllMembers() : Array<MemberEntity> {
 		return this._clone(MembersMockData);
 	}
 }

--- a/04 DisplayData/src/components/members/membersPage.tsx
+++ b/04 DisplayData/src/components/members/membersPage.tsx
@@ -24,8 +24,7 @@ export default class MembersPage extends React.Component<Props, State> {
    // Standard react lifecycle function:
    // https://facebook.github.io/react/docs/component-specs.html
    public componentWillMount() {
-     var memberAPI : MemberAPI = new MemberAPI();
-     this.state.members = memberAPI.getAllMembers();
+     this.state.members = MemberAPI.getAllMembers();
    }
 
 

--- a/05 Presentational Comp/src/api/memberAPI.ts
+++ b/05 Presentational Comp/src/api/memberAPI.ts
@@ -3,14 +3,16 @@ import MembersMockData from './memberMockData'
 import * as _ from 'lodash'
 // Sync mock data API, inspired from:
 // https://gist.github.com/coryhouse/fd6232f95f9d601158e4
-export default class MemberAPI {
+class MemberAPI {
   //This would be performed on the server in a real app. Just stubbing in.
-  private static _clone (item) {
+  private _clone (item) {
   	return JSON.parse(JSON.stringify(item)); //return cloned copy so that the item is passed by value instead of by reference
   };
 
   // Just return a copy of the mock data
-  static getAllMembers() : Array<MemberEntity> {
+  getAllMembers() : Array<MemberEntity> {
 		return this._clone(MembersMockData);
 	}
 }
+
+export default new MemberAPI();

--- a/05 Presentational Comp/src/api/memberAPI.ts
+++ b/05 Presentational Comp/src/api/memberAPI.ts
@@ -5,12 +5,12 @@ import * as _ from 'lodash'
 // https://gist.github.com/coryhouse/fd6232f95f9d601158e4
 export default class MemberAPI {
   //This would be performed on the server in a real app. Just stubbing in.
-  private _clone (item) {
+  private static _clone (item) {
   	return JSON.parse(JSON.stringify(item)); //return cloned copy so that the item is passed by value instead of by reference
   };
 
   // Just return a copy of the mock data
-  getAllMembers() : Array<MemberEntity> {
+  static getAllMembers() : Array<MemberEntity> {
 		return this._clone(MembersMockData);
 	}
 }

--- a/05 Presentational Comp/src/components/members/membersPage.tsx
+++ b/05 Presentational Comp/src/components/members/membersPage.tsx
@@ -25,8 +25,7 @@ export default class MembersPage extends React.Component<Props, State> {
    // Standard react lifecycle function:
    // https://facebook.github.io/react/docs/component-specs.html
    public componentWillMount() {
-     var memberAPI : MemberAPI = new MemberAPI();
-     this.state.members = memberAPI.getAllMembers();
+     this.state.members = MemberAPI.getAllMembers();
    }
 
    public render() {

--- a/06 AJAX Call/src/api/memberAPI.ts
+++ b/06 AJAX Call/src/api/memberAPI.ts
@@ -8,17 +8,17 @@ import * as Q from 'q'
 // https://gist.github.com/coryhouse/fd6232f95f9d601158e4
 export default class MemberAPI {
   //This would be performed on the server in a real app. Just stubbing in.
-  private _clone (item) {
+  private static _clone (item) {
   	return JSON.parse(JSON.stringify(item)); //return cloned copy so that the item is passed by value instead of by reference
   };
 
   // Just return a copy of the mock data
-  getAllMembers() : Array<MemberEntity> {
+  static getAllMembers() : Array<MemberEntity> {
 		return this._clone(MembersMockData);
 	}
 
   //Q.Promise<Array<MemberEntity>
-  getAllMembersAsync() : Q.Promise<MemberEntity[]> {
+  static getAllMembersAsync() : Q.Promise<MemberEntity[]> {
     // Going more modern: check 'fetch' and ES6 Promise
     var deferred = Q.defer<Array<MemberEntity>>();
 

--- a/06 AJAX Call/src/api/memberAPI.ts
+++ b/06 AJAX Call/src/api/memberAPI.ts
@@ -6,19 +6,19 @@ import * as Q from 'q'
 
 // Sync mock data API, inspired from:
 // https://gist.github.com/coryhouse/fd6232f95f9d601158e4
-export default class MemberAPI {
+class MemberAPI {
   //This would be performed on the server in a real app. Just stubbing in.
-  private static _clone (item) {
+  private _clone (item) {
   	return JSON.parse(JSON.stringify(item)); //return cloned copy so that the item is passed by value instead of by reference
   };
 
   // Just return a copy of the mock data
-  static getAllMembers() : Array<MemberEntity> {
+  getAllMembers() : Array<MemberEntity> {
 		return this._clone(MembersMockData);
 	}
 
   //Q.Promise<Array<MemberEntity>
-  static getAllMembersAsync() : Q.Promise<MemberEntity[]> {
+  getAllMembersAsync() : Q.Promise<MemberEntity[]> {
     // Going more modern: check 'fetch' and ES6 Promise
     var deferred = Q.defer<Array<MemberEntity>>();
 
@@ -42,3 +42,5 @@ export default class MemberAPI {
     return deferred.promise;
   }
 }
+
+export default new MemberAPI();

--- a/06 AJAX Call/src/components/members/membersPage.tsx
+++ b/06 AJAX Call/src/components/members/membersPage.tsx
@@ -24,9 +24,8 @@ export default class MembersPage extends React.Component<Props, State> {
 
    // Changing to componentDidMount to handle initial ajax request response
    public componentDidMount() {
-     var memberAPI : MemberAPI = new MemberAPI();
      //this.state.members = memberAPI.getAllMembers();
-     var promise  : Q.Promise<MemberEntity[]> = memberAPI.getAllMembersAsync();
+     var promise  : Q.Promise<MemberEntity[]> = MemberAPI.getAllMembersAsync();
 
      promise.done(function (members) {
         // React only triggers a re-render if you use setState to update the state.

--- a/06 AJAX Call/src/components/members/membersPage.tsx
+++ b/06 AJAX Call/src/components/members/membersPage.tsx
@@ -24,7 +24,6 @@ export default class MembersPage extends React.Component<Props, State> {
 
    // Changing to componentDidMount to handle initial ajax request response
    public componentDidMount() {
-     //this.state.members = memberAPI.getAllMembers();
      var promise  : Q.Promise<MemberEntity[]> = MemberAPI.getAllMembersAsync();
 
      promise.done(function (members) {

--- a/07 Form/src/api/memberAPI.ts
+++ b/07 Form/src/api/memberAPI.ts
@@ -4,29 +4,25 @@ import * as _ from 'lodash'
 // Sync mock data API, inspired from:
 // https://gist.github.com/coryhouse/fd6232f95f9d601158e4
 export default class MemberAPI {
-  private _idSeed : number;
-
-  public constructor() {
-    this._idSeed = 20;
-  }
+  private static _idSeed : number = 20;
 
   //This would be performed on the server in a real app. Just stubbing in.
-  private _clone (item) {
+  private static _clone (item) {
   	return JSON.parse(JSON.stringify(item)); //return cloned copy so that the item is passed by value instead of by reference
   };
 
   //This would be performed on the server in a real app. Just stubbing in.
-  _generateId() : number {
+  static _generateId() : number {
   	return this._idSeed++;
   };
 
 
   // Just return a copy of the mock data
-  getAllMembers() : Array<MemberEntity> {
+  static getAllMembers() : Array<MemberEntity> {
 		return this._clone(MembersMockData);
 	}
 
-  saveAuthor(member: MemberEntity) {
+  static saveAuthor(member: MemberEntity) {
 		//pretend an ajax call to web api is made here
 		console.log('Pretend this just saved the author to the DB via AJAX call...');
 

--- a/07 Form/src/api/memberAPI.ts
+++ b/07 Form/src/api/memberAPI.ts
@@ -3,26 +3,30 @@ import MembersMockData from './memberMockData'
 import * as _ from 'lodash'
 // Sync mock data API, inspired from:
 // https://gist.github.com/coryhouse/fd6232f95f9d601158e4
-export default class MemberAPI {
-  private static _idSeed : number = 20;
+class MemberAPI {
+  private _idSeed : number;
+
+  public constructor() {
+      this._idSeed = 20;
+  }
 
   //This would be performed on the server in a real app. Just stubbing in.
-  private static _clone (item) {
+  private _clone (item) {
   	return JSON.parse(JSON.stringify(item)); //return cloned copy so that the item is passed by value instead of by reference
   };
 
   //This would be performed on the server in a real app. Just stubbing in.
-  static _generateId() : number {
+  _generateId() : number {
   	return this._idSeed++;
   };
 
 
   // Just return a copy of the mock data
-  static getAllMembers() : Array<MemberEntity> {
+  getAllMembers() : Array<MemberEntity> {
 		return this._clone(MembersMockData);
 	}
 
-  static saveAuthor(member: MemberEntity) {
+  saveAuthor(member: MemberEntity) {
 		//pretend an ajax call to web api is made here
 		console.log('Pretend this just saved the author to the DB via AJAX call...');
 
@@ -41,3 +45,5 @@ export default class MemberAPI {
 	}
 
 }
+
+export default new MemberAPI();

--- a/07 Form/src/components/member/memberPage.tsx
+++ b/07 Form/src/components/member/memberPage.tsx
@@ -73,8 +73,7 @@ public saveMember(event) {
     return;
   }
 
-  var memberAPI : MemberAPI = new MemberAPI();
-  memberAPI.saveAuthor(this.state.member);
+  MemberAPI.saveAuthor(this.state.member);
 
   var newState : State = objectAssign({}, this.state, {dirty: true});
   this.setState(newState);

--- a/07 Form/src/components/members/membersPage.tsx
+++ b/07 Form/src/components/members/membersPage.tsx
@@ -26,8 +26,7 @@ export default class MembersPage extends React.Component<Props, State> {
    // Standard react lifecycle function:
    // https://facebook.github.io/react/docs/component-specs.html
    public componentWillMount() {
-     var memberAPI : MemberAPI = new MemberAPI();
-     this.state.members = memberAPI.getAllMembers();
+     this.state.members = MemberAPI.getAllMembers();
    }
 
    public render() {

--- a/08 ParamNavigation/src/api/memberAPI.ts
+++ b/08 ParamNavigation/src/api/memberAPI.ts
@@ -3,31 +3,35 @@ import MembersMockData from './memberMockData'
 import * as _ from 'lodash'
 // Sync mock data API, inspired from:
 // https://gist.github.com/coryhouse/fd6232f95f9d601158e4
-export default class MemberAPI {
-  private static _idSeed : number = 20;
+class MemberAPI {
+  private _idSeed : number;
+
+  public constructor() {
+      this._idSeed = 20;
+  }
 
   //This would be performed on the server in a real app. Just stubbing in.
-  private static _clone (item) {
+  private _clone (item) {
   	return JSON.parse(JSON.stringify(item)); //return cloned copy so that the item is passed by value instead of by reference
   };
 
   //This would be performed on the server in a real app. Just stubbing in.
-  static _generateId() : number {
+  _generateId() : number {
   	return this._idSeed++;
   };
 
 
   // Just return a copy of the mock data
-  static getAllMembers() : Array<MemberEntity> {
+  getAllMembers() : Array<MemberEntity> {
 		return this._clone(MembersMockData);
 	}
 
-  static getMemberById(id : number) : MemberEntity {
+  getMemberById(id : number) : MemberEntity {
 		var member = _.find(MembersMockData, {id: id});
 		return this._clone(member);
 	}
 
-  static saveAuthor(member: MemberEntity) {
+  saveAuthor(member: MemberEntity) {
 		//pretend an ajax call to web api is made here
 		console.log('Pretend this just saved the author to the DB via AJAX call...');
 
@@ -46,3 +50,5 @@ export default class MemberAPI {
 	}
 
 }
+
+export default new MemberAPI();

--- a/08 ParamNavigation/src/api/memberAPI.ts
+++ b/08 ParamNavigation/src/api/memberAPI.ts
@@ -4,34 +4,30 @@ import * as _ from 'lodash'
 // Sync mock data API, inspired from:
 // https://gist.github.com/coryhouse/fd6232f95f9d601158e4
 export default class MemberAPI {
-  private _idSeed : number;
-
-  public constructor() {
-    this._idSeed = 20;
-  }
+  private static _idSeed : number = 20;
 
   //This would be performed on the server in a real app. Just stubbing in.
-  private _clone (item) {
+  private static _clone (item) {
   	return JSON.parse(JSON.stringify(item)); //return cloned copy so that the item is passed by value instead of by reference
   };
 
   //This would be performed on the server in a real app. Just stubbing in.
-  _generateId() : number {
+  static _generateId() : number {
   	return this._idSeed++;
   };
 
 
   // Just return a copy of the mock data
-  getAllMembers() : Array<MemberEntity> {
+  static getAllMembers() : Array<MemberEntity> {
 		return this._clone(MembersMockData);
 	}
 
-  getMemberById(id : number) : MemberEntity {
+  static getMemberById(id : number) : MemberEntity {
 		var member = _.find(MembersMockData, {id: id});
 		return this._clone(member);
 	}
 
-  saveAuthor(member: MemberEntity) {
+  static saveAuthor(member: MemberEntity) {
 		//pretend an ajax call to web api is made here
 		console.log('Pretend this just saved the author to the DB via AJAX call...');
 

--- a/08 ParamNavigation/src/components/member/memberPage.tsx
+++ b/08 ParamNavigation/src/components/member/memberPage.tsx
@@ -33,9 +33,8 @@ export default class MemberPage extends React.Component<Props, State> {
     var memberId = this.props.params.id;
 
     if(memberId) {
-      var memberAPI : MemberAPI = new MemberAPI();
       var memberIdNumber : number = parseInt(memberId);
-      var newState : State = objectAssign({}, this.state, {dirty: false, member: memberAPI.getMemberById(memberIdNumber)});
+      var newState : State = objectAssign({}, this.state, {dirty: false, member: MemberAPI.getMemberById(memberIdNumber)});
       return this.setState(newState);
 
     }
@@ -81,8 +80,7 @@ public saveMember(event) {
     return;
   }
 
-  var memberAPI : MemberAPI = new MemberAPI();
-  memberAPI.saveAuthor(this.state.member);
+  MemberAPI.saveAuthor(this.state.member);
 
   var newState : State = objectAssign({}, this.state, {dirty: true});
   this.setState(newState);

--- a/08 ParamNavigation/src/components/members/membersPage.tsx
+++ b/08 ParamNavigation/src/components/members/membersPage.tsx
@@ -26,8 +26,7 @@ export default class MembersPage extends React.Component<Props, State> {
    // Standard react lifecycle function:
    // https://facebook.github.io/react/docs/component-specs.html
    public componentWillMount() {
-     var memberAPI : MemberAPI = new MemberAPI();
-     this.state.members = memberAPI.getAllMembers();
+     this.state.members = MemberAPI.getAllMembers();
    }
 
    public render() {


### PR DESCRIPTION
The best solution I've found is to refactor MemberApi into a static class, since there is no need to instance it and it must keep track of the current id regardless of where it is used.