### PR TITLE
Clean lazy-loading logic. Added types.

### DIFF
--- a/16 Lazy Loading/src/components/members/membersPage.tsx
+++ b/16 Lazy Loading/src/components/members/membersPage.tsx
@@ -1,81 +1,65 @@
 import * as React from 'react';
+import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
-import {Link} from 'react-router';
+import { Link } from 'react-router';
 import MemberEntity from '../../api/memberEntity';
 import MemberRow from './memberRow';
 import loadMembers from '../../actions/loadMembers';
 
-// Presentational
-
-// extends React.Props<MembersPage>
-interface Props extends React.Props<MembersPage>{
-  members? : Array<any>;
+interface Props {
+  members? : MemberEntity[];
   loadMembers? : () => void;
 }
 
 class MembersPage extends React.Component<Props, {}> {
-
-   // Standard react lifecycle function:
-   // https://facebook.github.io/react/docs/component-specs.html
    public componentDidMount() {
      this.props.loadMembers();
    }
 
-   public render() {
-     if(!this.props.members)
-        return (<div>No data</div>)
+  public render() {
+    if(!this.props.members) {
+      return (<div>No data</div>);
+    }
 
-
-       return (
-        <div className="row">
-          <h2> Members Page</h2>
-          <Link to="/member">New Member</Link>
-          <table className="table">
-            <thead>
-              <tr>
-                <th>
-                  Avatar
-                </th>
-                <th>
-                  Id
-                </th>
-                <th>
-                  Name
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-            {
-              this.props.members.map((member : MemberEntity) =>
-                  <MemberRow key={member.id} member = {member}/>
-                )
-              }
-            </tbody>
-          </table>
-        </div>
-       );
+    return (
+      <div className="row">
+        <h2> Members Page</h2>
+        <Link to="/member">New Member</Link>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>
+                Avatar
+              </th>
+              <th>
+                Id
+              </th>
+              <th>
+                Name
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+          {
+            this.props.members.map(member =>
+              <MemberRow key={ member.id } member={ member }/>)
+          }
+          </tbody>
+        </table>
+      </div>);
   }
 }
 
-// Container
-
-const mapStateToProps = (state) => {
-    return {
-      members: state.members
-    }
+const mapStateToProps = (state: any): Props => {
+  return {
+    members: state.members,
+  };
 }
 
-
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = (dispatch: Dispatch): Props => {
   return {
     loadMembers: () => {return dispatch(loadMembers())}
-  }
+  };
 }
 
-const ContainerMembersPage = connect(
-                                   mapStateToProps
-                                  ,mapDispatchToProps
-                                )(MembersPage)
-
-
-export default ContainerMembersPage;
+export default connect(mapStateToProps, mapDispatchToProps)(MembersPage);

--- a/16 Lazy Loading/src/index.tsx
+++ b/16 Lazy Loading/src/index.tsx
@@ -6,36 +6,27 @@ import * as _AboutPage from "./components/about/aboutPage";
 import * as _MemberPage from "./components/member/memberPage";
 import * as _MembersPage from "./components/members/membersPage";
 
-namespace Chunks {
-  export const About = "AboutPage";
-  export const Member = "MemberPages";
-}
-
 type LoadCallback = (error: any, component: React.ComponentClass<any>) => void;
 
 function loadAboutPage(location: any, callback: LoadCallback) {
-  loadModule<typeof _AboutPage>(
-    "./components/about/aboutPage",
-    Chunks.About,
-    loadedModule => callback(null, loadedModule.default));
+  require.ensure(
+    [],
+    () => callback(null, (require("./components/about/aboutPage") as typeof _AboutPage).default),
+    "AboutPage");
 };
 
 function loadMemberPage(location: any, callback: LoadCallback) {
-  loadModule<typeof _MemberPage>(
-    "./components/member/memberPage",
-    Chunks.Member,
-    loadedModule => callback(null, loadedModule.default));
+  require.ensure(
+    [],
+    () => callback(null, (require("./components/member/memberPage") as typeof _MemberPage).default),
+    "MemberPages");
 }
 
 function loadMembersPage(location: any, callback: LoadCallback) {
-  loadModule<typeof _MembersPage>(
-    "./components/member/membersPage",
-    Chunks.Member,
-    loadedModule => callback(null, loadedModule.default));
-}
-
-function loadModule<TModule>(moduleName: string, chunkName: string, callback: (module: TModule) => void): void {
-  require.ensure([moduleName], (require) => callback(require(moduleName) as TModule), chunkName);
+  require.ensure(
+    [],
+    () => callback(null, (require("./components/members/membersPage") as typeof _MembersPage).default),
+    "MemberPages");
 }
 
 ReactDOM.render(

--- a/16 Lazy Loading/src/index.tsx
+++ b/16 Lazy Loading/src/index.tsx
@@ -2,69 +2,50 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Router, Route, IndexRoute, hashHistory } from 'react-router';
 import App from './components/app.tsx';
+import * as _AboutPage from "./components/about/aboutPage";
+import * as _MemberPage from "./components/member/memberPage";
+import * as _MembersPage from "./components/members/membersPage";
 
-//Loading single component in one chunk
-const lazyLoadAboutComponent = () => {
-  return {
-      getComponent: (location, callback)=> {
-        require.ensure([], require => {
-          callback(null, require('./components/about/aboutPage')["default"]);
-        }, 'AboutPage');
-      }
-    }
+namespace Chunks {
+  export const About = "AboutPage";
+  export const Member = "MemberPages";
+}
+
+type LoadCallback = (error: any, component: React.ComponentClass<any>) => void;
+
+function loadAboutPage(location: any, callback: LoadCallback) {
+  loadModule<typeof _AboutPage>(
+    "./components/about/aboutPage",
+    Chunks.About,
+    loadedModule => callback(null, loadedModule.default));
 };
 
-//Loading group of components in one chunk
-const lazyLoadMemberComponent = () => {
-  return {
-      getComponent: (location, callback) => {
-        require.ensure(['./components/member/memberPage', './components/members/membersPage'], require => {
-          callback(null, require('./components/member/memberPage')["default"]);
-        }, 'MemberComponents');
-      }
-    }
-};
+function loadMemberPage(location: any, callback: LoadCallback) {
+  loadModule<typeof _MemberPage>(
+    "./components/member/memberPage",
+    Chunks.Member,
+    loadedModule => callback(null, loadedModule.default));
+}
 
-const lazyLoadMembersComponent = () => {
-  return {
-      getComponent: (location, callback) => {
-        require.ensure(['./components/member/memberPage', './components/members/membersPage'], require => {
-          callback(null, require('./components/members/membersPage')["default"]);
-        }, 'MemberComponents');
-      }
-    }
-};
+function loadMembersPage(location: any, callback: LoadCallback) {
+  loadModule<typeof _MembersPage>(
+    "./components/member/membersPage",
+    Chunks.Member,
+    loadedModule => callback(null, loadedModule.default));
+}
 
-//Second approach to load group of components in one chunk could be:
-/*
-    const lazyLoadMemberAreaPage = (pageName) => {
-      return {
-          getComponent: (location, callback) => {
-            require.ensure(['./components/member/memberPage', './components/members/membersPage'], require => {
-              switch(pageName) {
-                case 'member':
-                  callback(null, require('./components/member/memberPage')["default"]);
-                  break;
-
-                case 'members':
-                  callback(null, require('./components/members/membersPage')["default"]);
-                  break;
-              }
-            }, 'MemberComponents');
-          }
-        }
-    };
-*/
+function loadModule<TModule>(moduleName: string, chunkName: string, callback: (module: TModule) => void): void {
+  require.ensure([moduleName], (require) => callback(require(moduleName) as TModule), chunkName);
+}
 
 ReactDOM.render(
   <Router history={hashHistory}>
     <Route  path="/" component= {App} >
-      <IndexRoute {...lazyLoadAboutComponent()} />
-      <Route path="/about" {...lazyLoadAboutComponent()} />
-      <Route path="/members" {...lazyLoadMembersComponent()} />
-      <Route path="/member" {...lazyLoadMemberComponent()} />
-      <Route path="/memberEdit/:id" {...lazyLoadMemberComponent()} />
+      <IndexRoute getComponent={ loadAboutPage } />
+      <Route path="/about" getComponent={ loadAboutPage } />
+      <Route path="/members" getComponent={ loadMembersPage } />
+      <Route path="/member" getComponent={ loadMemberPage } />
+      <Route path="/memberEdit/:id" getComponent={ loadMemberPage } />
     </Route>
-  </Router>
-
-  , document.getElementById('root'));
+  </Router>,
+  document.getElementById('root'));


### PR DESCRIPTION
No functional change. Main changes:
- Declare **types of lazy-loaded modules**. Added _ imports that are removed by TypeScript at compile time (not because of the underscore, that's just a notation, but because they are only used as types).
- Added **types to one component** as an example. Minor clean up there. Not applied to other components yet, I'd like to get feedback first but I'd be happy to do it in the context of this PR.
- Initially I tried to **extract simpler methods to lazy-load modules**, but Webpack doesn't allow it, as the require.ensure method must be used with literals (both for modules and chunk names), otherwise the preprocessor won't do its job well.
    - This is a big **showstopper** to me: I'd like to encapsulate lazy-require calls so I don't spread them throughout the application code. Specifically we're polluting with:
    - Webpack info: what if we change to another build system? What if System.import() becomes standard finally?
    - Chunk information: what if we change how we create our chunks? What if we rename and forget any literal?
