### PR TITLE
Add missing reference to pageContainer.tsx

### DIFF
--- a/08 ParamNavigation/readme.md
+++ b/08 ParamNavigation/readme.md
@@ -261,6 +261,7 @@ import * as toastr from 'toastr';
 import { memberAPI } from '../../api/member';
 - import { MemberEntity } from '../../model';
 + import { MemberEntity, MemberErrors } from '../../model';
++ import { memberFormValidation } from './memberFormValidation';
 import { MemberPage } from './page';
 
 interface Props {


### PR DESCRIPTION
The walk through misses the reference to memberFormValidation in pageContainer.tsx.