### PR TITLE
Issue 126: Update JQuery version on affected samples

### DIFF
--- a/11 TestReducer/package.json
+++ b/11 TestReducer/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "bootstrap": "^3.3.5",
-    "jquery": "^2.1.4",
+    "jquery": "^3.2.1",
     "lodash": "^4.5.1",
     "object-assign": "^4.0.1",
     "q": "^1.4.1",

--- a/12 TestAction/package.json
+++ b/12 TestAction/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "bootstrap": "^3.3.5",
-    "jquery": "^2.1.4",
+    "jquery": "^3.2.1",
     "lodash": "^4.5.1",
     "object-assign": "^4.0.1",
     "q": "^1.4.1",

--- a/13 TestComponent/package.json
+++ b/13 TestComponent/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "bootstrap": "^3.3.5",
-    "jquery": "^2.1.4",
+    "jquery": "^3.2.1",
     "lodash": "^4.5.1",
     "object-assign": "^4.0.1",
     "q": "^1.4.1",

--- a/14 AsyncCalls_Redux_Saga/package.json
+++ b/14 AsyncCalls_Redux_Saga/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "bootstrap": "^3.3.5",
-    "jquery": "^2.1.4",
+    "jquery": "^3.2.1",
     "lodash": "^4.5.1",
     "object-assign": "^4.0.1",
     "q": "^1.4.1",

--- a/15 Lazy Loading/package.json
+++ b/15 Lazy Loading/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "bootstrap": "^3.3.5",
-    "jquery": "^2.1.4",
+    "jquery": "^3.2.1",
     "lodash": "^4.5.1",
     "object-assign": "^4.0.1",
     "q": "^1.4.1",

--- a/16 Custom Middleware/package.json
+++ b/16 Custom Middleware/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "bootstrap": "^3.3.5",
-    "jquery": "^2.1.4",
+    "jquery": "^3.2.1",
     "lodash": "^4.5.1",
     "object-assign": "^4.0.1",
     "q": "^1.4.1",

--- a/17 ReactHotLoader/package.json
+++ b/17 ReactHotLoader/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "bootstrap": "^3.3.5",
-    "jquery": "^2.1.4",
+    "jquery": "^3.2.1",
     "lodash": "^4.5.1",
     "object-assign": "^4.0.1",
     "q": "^1.4.1",
@@ -52,6 +52,6 @@
     "typescript": "^1.8.9",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.13",
-    "webpack-dev-server": "^1.14.1"   
+    "webpack-dev-server": "^1.14.1"
   }
 }


### PR DESCRIPTION
- JQuery version has been upgraded for samples 11 to 17 (from version 2.1.4. to version 3.2.1.). 
- Samples 11 to 16 seem to be working as intended with the upgrade. 
- Sample 17 has not been tested, as it is not working currently and needs to be updated/refactored accordingly. After further talk with @brauliodiez, it has been agreed on preemptively updating the version as well. Once Sample 17 is refactored, it will be necessary to double-check that the changes in JQuery version are not having any effects whatsoever on the intended functionality.