### PR TITLE
Fix New Member form in sample 08 Param Navigation #147

### DIFF
--- a/08 ParamNavigation/src/api/member/index.ts
+++ b/08 ParamNavigation/src/api/member/index.ts
@@ -56,7 +56,15 @@ const insertMember = (member: MemberEntity) => {
 };
 
 const fetchMemberById = (id: number): Promise<MemberEntity> => {
-  const member = mockMembers.find(m => m.id === id);
+  const index: number = mockMembers.findIndex(m => m.id === id);
+  const member: MemberEntity = index >= 0 ?
+    mockMembers[index]
+    :
+    {
+      id: -1,
+      login: '',
+      avatar_url: '',
+    };
 
   return Promise.resolve(member);
 }


### PR DESCRIPTION
Function fetchMemberById has been modified to return an empty default MemberEntity if the member id doesn't exist.