### PR TITLE
hooks/13_login_form/fix function parameters

### DIFF
--- a/hooks/13_LoginForm/Readme.md
+++ b/hooks/13_LoginForm/Readme.md
@@ -424,7 +424,7 @@ _./src/pages/loginPage.tsx_
 ```diff
 interface PropsForm {
   onLogin: () => void;
-+  onUpdateField: (string, any) => void;
++  onUpdateField: (name: string, value: any) => void;
 +  loginInfo : LoginEntity;
 }
 

--- a/hooks/13_LoginForm/src/pages/loginPage.tsx
+++ b/hooks/13_LoginForm/src/pages/loginPage.tsx
@@ -70,7 +70,7 @@ export const LoginPage = withStyles(styles)(withRouter<Props>(LoginPageInner));
 
 interface PropsForm {
   onLogin: () => void;
-  onUpdateField: (string, any) => void;
+  onUpdateField: (name: string, value: any) => void;
   loginInfo: LoginEntity;
 }
 


### PR DESCRIPTION
I think it's a typo, but there is forgotten parameters name before types